### PR TITLE
Add Express type annotations for fibRoute (fixes it)

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
+import Express from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Express.Request, res : Express.Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fixes esLint errors by importing Express for its types, and then typing parameters accordingly. Tested via eslint CI.