### PR TITLE
Add types to fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
+import Express from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Express.Request, res: Express.Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fixes the eslint error, solving issue #3. Tested to fix the issue. As the types are cosmetic, there's no functional change and so testing shouldn't be required, but I still doublechecked the fib API worked.

cc @olegp-andrew -- can I get a review?