### PR TITLE
add type annotations to `src/fib.ts`

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Fix linting errors by adding type annotations to default export `fibonacci` in `src/fib.ts`